### PR TITLE
Add GOOS and GOARCH to build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,10 @@ print-version: ## Print version
 
 build: $(GO_DEPENDENCIES) clean ## Build binary for current OS
 	go mod download
-	CGO_ENABLED=$(CGO_ENABLED) $(GO) $(BUILD_TARGET) $(BUILDFLAGS) -o build/$(NAME) $(MAIN_SRC_FILE)
+	CGO_ENABLED=$(CGO_ENABLED) GOARCH=$(GOARCH) GOOS=$(GOOS) $(GO) $(BUILD_TARGET) $(BUILDFLAGS) -o build/$(NAME) $(MAIN_SRC_FILE)
 
 build-all: $(GO_DEPENDENCIES) build make-reports-dir ## Build all files - runtime, all tests etc.
-	CGO_ENABLED=$(CGO_ENABLED) $(GOTEST) -run=nope -tags=integration -failfast -short ./... $(BUILDFLAGS)
+	CGO_ENABLED=$(CGO_ENABLED) GOARCH=$(GOARCH) GOOS=$(GOOS) $(GOTEST) -run=nope -tags=integration -failfast -short ./... $(BUILDFLAGS)
 
 tidy-deps: ## Cleans up dependencies
 	$(GO) mod tidy


### PR DESCRIPTION
I adding multi-arch image support to kaniko and would be great if we can expose the GOOS and GOARCH in build target to fix this Dockerfile file [here](https://github.com/GoogleContainerTools/kaniko/blob/master/deploy/Dockerfile#L53)