### PR TITLE
Handle non-ACR registries without long delay

### DIFF
--- a/pkg/credhelper/helper.go
+++ b/pkg/credhelper/helper.go
@@ -18,6 +18,8 @@ package credhelper
 import (
 	"errors"
 	"fmt"
+	"net/url"
+	"regexp"
 
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/chrismellard/docker-credential-acr-env/pkg/registry"
@@ -25,7 +27,12 @@ import (
 	"github.com/docker/docker-credential-helpers/credentials"
 )
 
-const tokenUsername = "<token>"
+var acrPattern = regexp.MustCompile(`(^[a-zA-Z0-9][a-zA-Z0-9-_]*)\.azurecr.io$`)
+
+const (
+	mcrHostname   = "mcr.microsoft.com"
+	tokenUsername = "<token>"
+)
 
 type ACRCredHelper struct {
 }
@@ -42,7 +49,26 @@ func (a ACRCredHelper) Delete(_ string) error {
 	return errors.New("list is unimplemented")
 }
 
+func isACRRegistry(input string) bool {
+	serverURL, err := url.Parse("https://" + input)
+	if err != nil {
+		return false
+	}
+	if serverURL.Hostname() == mcrHostname {
+		return true
+	}
+	matches := acrPattern.FindStringSubmatch(serverURL.Hostname())
+	if len(matches) == 0 {
+		return false
+	}
+	return true
+}
+
 func (a ACRCredHelper) Get(serverURL string) (string, string, error) {
+	if !isACRRegistry(serverURL) {
+		return "", "", errors.New("serverURL does not refer to Azure Container Registry")
+	}
+
 	spToken, settings, err := token.GetServicePrincipalTokenFromEnvironment()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to acquire sp token %w", err)

--- a/pkg/credhelper/helper.go
+++ b/pkg/credhelper/helper.go
@@ -27,7 +27,7 @@ import (
 	"github.com/docker/docker-credential-helpers/credentials"
 )
 
-var acrPattern = regexp.MustCompile(`(^[a-zA-Z0-9][a-zA-Z0-9-_]*)\.azurecr.io$`)
+var acrRE = regexp.MustCompile(`.*\.azurecr\.io|.*\.azurecr\.cn|.*\.azurecr\.de|.*\.azurecr\.us`)
 
 const (
 	mcrHostname   = "mcr.microsoft.com"
@@ -57,7 +57,7 @@ func isACRRegistry(input string) bool {
 	if serverURL.Hostname() == mcrHostname {
 		return true
 	}
-	matches := acrPattern.FindStringSubmatch(serverURL.Hostname())
+	matches := acrRE.FindStringSubmatch(serverURL.Hostname())
 	if len(matches) == 0 {
 		return false
 	}

--- a/pkg/credhelper/helper_test.go
+++ b/pkg/credhelper/helper_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright © 2022 Chris Mellard chris.mellard@icloud.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package credhelper
+
+import "testing"
+
+// TestIsACRHelper tests whether URLs are detected as being ACR/MCR registry
+// hosts, to determine whether the cred helper should fail fast.
+func TestIsACRHelper(t *testing.T) {
+	for _, c := range []struct {
+		url  string
+		want bool
+	}{
+		{"myregistry.azurecr.io", true},
+		{"myregistry.azurecr.cn", true},
+		{"myregistry.azurecr.de", true},
+		{"myregistry.azurecr.us", true},
+		{"mcr.microsoft.com", true},
+		{"myregistry.azurecr.me", false}, // not a known tld
+		{"notacr.xcr.example", false},
+		{"127.0.0.1:12345", false},
+		{"localhost:12345", false},
+		{"notaurl-)(*$@)(*@)(*", false},
+	} {
+		t.Run(c.url, func(t *testing.T) {
+			got := isACRRegistry(c.url)
+			if got != c.want {
+				t.Fatalf("got %t, want %t", got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/registry/const.go
+++ b/pkg/registry/const.go
@@ -16,11 +16,10 @@ limitations under the License.
 package registry
 
 import (
-	"context"
 	"time"
 )
 
-const secureScheme = "https://"
-
-var defaultTimeOut = time.Duration(30) * time.Second
-var OAuthHTTPContext = context.Background()
+const (
+	secureScheme   = "https://"
+	defaultTimeOut = time.Duration(30) * time.Second
+)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -29,6 +29,10 @@ import (
 func GetRegistryRefreshTokenFromAADExchange(serverURL string, principalToken *adal.ServicePrincipalToken, tenantID string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeOut)
 	defer cancel()
+
+	// If refreshing fails, don't try again, just fail.
+	principalToken.MaxMSIRefreshAttempts = 1
+
 	if err := principalToken.EnsureFreshWithContext(ctx); err != nil {
 		return "", fmt.Errorf("error refreshing sp token - %w", err)
 	}


### PR DESCRIPTION
Today, if this cred helper happens to be invoked for in non-ACR environment for a non-ACR registry, the helper hangs for minutes before eventually failing (as expected).

This change aims to make this failure much faster, in two ways (in two commits):
1. Enforce the 30-second timeout when ensuring a fresh principal token -- before this change, this method would wait and retry repeatedly if the server couldn't be reached.
2. Quickly check whether the registry server URL describes an ACR/MCR registry URL -- if it doesn't, fail immediately before even considering fetching or refreshing creds.

I based the regexp check on AWS's `ecr-login` cred helper, here: https://github.com/awslabs/amazon-ecr-credential-helper/blob/69c85dc22db6511932bbf119e1a0cc5c90c69a7f/ecr-login/api/client.go#L59 and included simple tests. Please let me know if there are other valid ACR URLs that we should be handling.

Thanks to @dprotaso for helping uncover these issues! 🙏 